### PR TITLE
http-same-pipeline #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ cargo build --release
 ## API
 
 - `GET /health` — returns `OK` when the server is enabled.
-- `POST /` with plain text — message attributed to `API`.
+- `POST /` with plain text — message attributed to `API` (ingest-only for Ollama unless you opt in; see below).
 - `POST /` with conversation JSON — `sender_name` and `message` (plus optional metadata).
 - `POST /` with evaluator JSON — `evaluator_name`, `sentiment`, and `message`.
+- **Auto-respond (Ollama):** default is off. Use query `?auto_respond=true` or JSON `"auto_respond": true` on conversation/evaluator payloads (JSON wins when present). When enabled, the message uses the same inference path as typing in the UI.
 - Example: `curl -X POST http://127.0.0.1:3000/ -H "Content-Type: application/json" -d '{"sender_name":"Agent 1","message":"Hi","sender_id":1,"receiver_id":0,"receiver_name":"UI","topic":"chat","timestamp":"11:44:50"}'`

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use egui::Frame;
 
 use crate::audit::AuditHandle;
 use crate::chat::ChatExample;
+use crate::incoming::MessageSource;
 use crate::ollama::{OllamaController, OllamaStatus};
 
 use std::sync::{Arc, Mutex};
@@ -574,6 +575,8 @@ impl eframe::App for MyApp {
                                                         content: format!("Testing Ollama API: {}", message),
                                                         from: Some("System".to_string()),
                                                         correlation: None,
+                                                        source: MessageSource::System,
+                                                        api_auto_respond: false,
                                                     };
                                                     tx.send(system_message).ok();
                                                     let request_id = crate::audit::new_id();
@@ -647,6 +650,8 @@ impl eframe::App for MyApp {
                                         content: "Please select Ollama Model.".to_string(),
                                         from: Some("System".to_string()),
                                         correlation: None,
+                                        source: MessageSource::System,
+                                        api_auto_respond: false,
                                     };
                                     tx_clone.send(bot_message).ok();
                                 } else if ollama_status == crate::ollama::OllamaStatus::Running {
@@ -677,6 +682,8 @@ impl eframe::App for MyApp {
                                         content: "Ollama is not running. Please check Ollama status.".to_string(),
                                         from: Some("System".to_string()),
                                         correlation: None,
+                                        source: MessageSource::System,
+                                        api_auto_respond: false,
                                     };
                                     tx_clone.send(bot_message).ok();
                                 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -6,6 +6,8 @@ use egui_inbox::UiInbox;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+use crate::incoming::{should_dispatch_to_model, MessageSource};
+
 #[derive(Debug, Clone)]
 pub struct MessageCorrelation {
     /// Carried for audit/export; IDs are also written to JSONL from server/ollama paths.
@@ -23,6 +25,9 @@ pub struct ChatMessage {
     pub content: String,
     pub from: Option<String>,
     pub correlation: Option<MessageCorrelation>,
+    pub source: MessageSource,
+    /// For [`MessageSource::Api`] only: when `true`, run the same Ollama pipeline as UI input. Default `false`.
+    pub api_auto_respond: bool,
 }
 
 #[derive(Debug)]
@@ -90,6 +95,8 @@ impl ChatExample {
                 content: "ams-chat Started".to_string(),
                 from: Some("System".to_string()),
                 correlation: None,
+                source: MessageSource::System,
+                api_auto_respond: false,
             }
         ];
 
@@ -152,11 +159,17 @@ impl ChatExample {
     pub fn ui(&mut self, ui: &mut Ui) {
         // Read incoming messages from inbox
         self.inbox.read(ui).for_each(|message| {
-            // Only add non-empty messages to prevent spacing issues
             if !message.content.trim().is_empty() {
                 let ts = Self::display_time_for_message(&message);
+                let run_handler = should_dispatch_to_model(message.source, message.api_auto_respond);
+                let text_for_model = message.content.clone();
                 self.messages.push(message);
                 self.message_timestamps.push(ts);
+                if run_handler {
+                    if let Some(handler) = &self.message_handler {
+                        handler(text_for_model);
+                    }
+                }
             }
         });
 
@@ -398,6 +411,8 @@ impl ChatExample {
                                     content: message_text.clone(),
                                     from: Some("Human".to_string()),
                                     correlation: None,
+                                    source: MessageSource::Human,
+                                    api_auto_respond: false,
                                 };
                                 self.messages.push(user_message);
                                 self.message_timestamps.push(Self::current_timestamp_string());
@@ -412,6 +427,8 @@ impl ChatExample {
                                         content: "Please select a model".to_string(),
                                         from: Some("System".to_string()),
                                         correlation: None,
+                                        source: MessageSource::System,
+                                        api_auto_respond: false,
                                     };
                                     tx.send(bot_message).ok();
                                 }

--- a/src/incoming/mod.rs
+++ b/src/incoming/mod.rs
@@ -1,0 +1,5 @@
+//! Inbound message classification and dispatch rules (HTTP vs UI vs system).
+
+mod source;
+
+pub use source::{should_dispatch_to_model, MessageSource};

--- a/src/incoming/source.rs
+++ b/src/incoming/source.rs
@@ -1,0 +1,34 @@
+/// Origin of a chat line. Used to decide whether inbound text should run the same Ollama pipeline as UI input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MessageSource {
+    /// Typed in the main chat input (always eligible for generation when a handler is set).
+    Human,
+    /// Injected via HTTP POST `/`.
+    Api,
+    /// System / assistant / tool lines; never triggers the user→model handler.
+    #[default]
+    System,
+}
+
+/// Whether this message should invoke the shared `MessageHandler` (Ollama path).
+#[inline]
+pub fn should_dispatch_to_model(source: MessageSource, api_auto_respond: bool) -> bool {
+    match source {
+        MessageSource::Human => true,
+        MessageSource::Api => api_auto_respond,
+        MessageSource::System => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_rules() {
+        assert!(should_dispatch_to_model(MessageSource::Human, false));
+        assert!(!should_dispatch_to_model(MessageSource::Api, false));
+        assert!(should_dispatch_to_model(MessageSource::Api, true));
+        assert!(!should_dispatch_to_model(MessageSource::System, true));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod audit;
 mod chat;
+mod incoming;
 mod ollama;
 mod server;
 

--- a/src/ollama.rs
+++ b/src/ollama.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use crate::audit::{self, AuditHandle, AuditRecord, SCHEMA_VERSION};
 use crate::chat::{ChatMessage, MessageCorrelation};
+use crate::incoming::MessageSource;
 
 const OLLAMA_URL: &str = "http://127.0.0.1:11434";
 
@@ -21,6 +22,8 @@ fn correlated_chat_message(
             request_id: request_id.to_string(),
             timestamp_rfc3339: audit::now_rfc3339(),
         }),
+        source: MessageSource::System,
+        api_auto_respond: false,
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,7 @@ use std::sync::mpsc;
 
 use crate::audit::{self, AuditRecord, SCHEMA_VERSION};
 use crate::chat::{ChatMessage, MessageCorrelation};
+use crate::incoming::MessageSource;
 
 // Conversation message format from web-agents
 #[derive(Serialize, Deserialize, Debug)]
@@ -25,6 +26,9 @@ struct ConversationMessage {
     topic: String,
     message: String,
     timestamp: String,
+    /// When present, overrides the `?auto_respond=` query flag for this request.
+    #[serde(default)]
+    auto_respond: Option<bool>,
 }
 
 // Evaluator result format from web-agents (Agent Evaluator)
@@ -34,6 +38,22 @@ struct EvaluatorResult {
     sentiment: String,
     message: String,
     timestamp: String,
+    #[serde(default)]
+    auto_respond: Option<bool>,
+}
+
+fn auto_respond_from_query(uri: &hyper::Uri) -> bool {
+    uri.query().map_or(false, |q| {
+        for pair in q.split('&') {
+            let mut parts = pair.splitn(2, '=');
+            let key = parts.next().unwrap_or("");
+            if key == "auto_respond" {
+                let v = parts.next().unwrap_or("");
+                return v.eq_ignore_ascii_case("true") || v == "1";
+            }
+        }
+        false
+    })
 }
 
 /// Start the HTTP server that receives POST requests
@@ -97,6 +117,8 @@ async fn handle_request(
                     .unwrap());
             }
 
+            let query_auto_respond = auto_respond_from_query(req.uri());
+
             let request_id = audit::new_id();
             let event_id = audit::new_id();
 
@@ -117,13 +139,18 @@ async fn handle_request(
                 "received POST body"
             );
 
-            let (message, payload_kind, audit_ts) =
+            let (message, payload_kind, audit_ts, api_auto_respond_effective) =
                 match serde_json::from_str::<ConversationMessage>(&body_str) {
                     Ok(conv_msg) => {
                         let ts = audit::resolve_from_optional_payload(Some(conv_msg.timestamp.as_str()));
+                        let api_auto =
+                            conv_msg
+                                .auto_respond
+                                .unwrap_or(query_auto_respond);
                         tracing::info!(
                             request_id = %request_id,
                             sender = %conv_msg.sender_name,
+                            auto_respond = api_auto,
                             "parsed conversation JSON"
                         );
                         (
@@ -136,18 +163,25 @@ async fn handle_request(
                                     request_id: request_id.clone(),
                                     timestamp_rfc3339: ts.clone(),
                                 }),
+                                source: MessageSource::Api,
+                                api_auto_respond: api_auto,
                             },
                             "conversation",
                             ts,
+                            api_auto,
                         )
                     }
                     Err(_) => match serde_json::from_str::<EvaluatorResult>(&body_str) {
                         Ok(eval_result) => {
                             let ts = audit::resolve_from_optional_payload(Some(eval_result.timestamp.as_str()));
+                            let api_auto = eval_result
+                                .auto_respond
+                                .unwrap_or(query_auto_respond);
                             tracing::info!(
                                 request_id = %request_id,
                                 evaluator = %eval_result.evaluator_name,
                                 sentiment = %eval_result.sentiment,
+                                auto_respond = api_auto,
                                 "parsed evaluator JSON"
                             );
                             (
@@ -163,13 +197,17 @@ async fn handle_request(
                                         request_id: request_id.clone(),
                                         timestamp_rfc3339: ts.clone(),
                                     }),
+                                    source: MessageSource::Api,
+                                    api_auto_respond: api_auto,
                                 },
                                 "evaluator",
                                 ts,
+                                api_auto,
                             )
                         }
                         Err(_) => {
                             let ts = audit::resolve_from_optional_payload(None);
+                            let api_auto = query_auto_respond;
                             (
                                 ChatMessage {
                                     content: body_str.to_string(),
@@ -180,9 +218,12 @@ async fn handle_request(
                                         request_id: request_id.clone(),
                                         timestamp_rfc3339: ts.clone(),
                                     }),
+                                    source: MessageSource::Api,
+                                    api_auto_respond: api_auto,
                                 },
                                 "plain",
                                 ts,
+                                api_auto,
                             )
                         }
                     },
@@ -198,6 +239,8 @@ async fn handle_request(
                 details: serde_json::json!({
                     "body_len": body_bytes.len(),
                     "payload_kind": payload_kind,
+                    "auto_respond": api_auto_respond_effective,
+                    "query_auto_respond": query_auto_respond,
                 }),
             };
             if let Err(e) = audit.append_json_line(&record) {
@@ -210,6 +253,7 @@ async fn handle_request(
                 "status": "ok",
                 "message": "Message received",
                 "request_id": request_id,
+                "auto_respond": api_auto_respond_effective,
             })
             .to_string();
 


### PR DESCRIPTION
src/incoming/ (modular, like audit/)
source.rs — MessageSource (Human | Api | System) and should_dispatch_to_model(source, api_auto_respond) (Human → always; Api → only if api_auto_respond; System → never). Small unit test for these rules.
mod.rs — re-exports only.
ChatMessage (chat.rs)
source: MessageSource
api_auto_respond: bool — meaningful for Api (HTTP); always false for Human/System UI paths.
Inbox path (chat.rs)
After inbox.read(ui), each message is appended as before; if should_dispatch_to_model(...), the same message_handler is called with content (mirrors UI → Ollama wiring in app.rs).
UI send still pushes a Human line and calls the handler directly (no duplicate, since Human lines are not delivered via the inbox).
server.rs
?auto_respond=true (or 1) parsed from the query string; default false.
Optional "auto_respond": true|false on conversation and evaluator JSON; if present, it overrides the query (unwrap_or(query_auto_respond)).
Plain text uses query only.
All HTTP-built messages use source: Api and the resolved flag.
Audit http_in details includes auto_respond, query_auto_respond.
JSON response includes "auto_respond": <effective bool>.
Defaults
auto_respond default is false — ingest-only unless clients opt in (matches “HTTP log + optional inference”).
Docs
README — short note on auto-respond and that JSON overrides the query when set.
Human–AI vs AI–AI is not branched yet; the same handler runs whenever dispatch says so (UI Human, or API with auto-respond). You can later gate on ChatUseMode inside the app.rs closure without changing incoming’s core rules.